### PR TITLE
Fix Issues and Improve Plotting in Python

### DIFF
--- a/src/fcwt/boilerplate.py
+++ b/src/fcwt/boilerplate.py
@@ -63,13 +63,12 @@ def plot(input, fs, f0=0, f1=0, fn=0, nthreads=1, scaling="lin", fast=False, nor
     ax2.set_title('CWT')
 
 
-    frequencySpacing = int(fn / YTickCount)                # Find the step size for the number of Y ticks
+    
+    yFrequencies = np.linspace(freqs[0], freqs[-1], num = YTickCount) # Select evenly-spaced frequencies, including the highest and lowest
 
-    yFrequencies = freqs[::frequencySpacing][0:YTickCount] # Select by stepping along this length; clamp at the number we are looking for in case we get one extra.
 
-
-    xTickPositions = np.arange(0, input.size, fs * XTickInterval) 
-    yTickPositions = np.arange(0, fn,         fn / YTickCount   )
+    xTickPositions = np.  arange(0, input.size, fs * XTickInterval)   # For X, just stepping in increments is suitable
+    yTickPositions = np.linspace(0, fn,         num = YTickCount  )   # For Y, we want to ensure f0 and f1 are included as ticks.
     
     xLabels  = np.arange(0, input.size/fs, XTickInterval)
 

--- a/src/fcwt/boilerplate.py
+++ b/src/fcwt/boilerplate.py
@@ -55,7 +55,7 @@ def plot(input, fs, f0=0, f1=0, fn=0, nthreads=1, scaling="lin", fast=False, nor
     # So we have fixed 10 ticks on the Y-axis; 10s occupies one X tick
 
     XTickInterval       = 10 # Seconds
-    YTickCount          = 10
+    YTickCount          = 9
     YLabelDecimalPlaces = 1
 
     ax2.set_xlabel('Time (s)')

--- a/src/fcwt/boilerplate.py
+++ b/src/fcwt/boilerplate.py
@@ -56,6 +56,7 @@ def plot(input, fs, f0=0, f1=0, fn=0, nthreads=1, scaling="lin", fast=False, nor
 
     XTickInterval       = 10 # Seconds
     YTickCount          = 10
+    YLabelDecimalPlaces = 1
 
     ax2.set_xlabel('Time (s)')
     ax2.set_ylabel('Frequency (Hz)')
@@ -72,8 +73,8 @@ def plot(input, fs, f0=0, f1=0, fn=0, nthreads=1, scaling="lin", fast=False, nor
     
     xLabels  = np.arange(0, input.size/fs, XTickInterval)
 
-    # Round the Y labels to be whole numbers
-    yLabels  = np. round(yFrequencies) # Will be co-erced to a string for us later.
+    # Round the Y labels to be 1 d.p.
+    yLabels  = np. round(yFrequencies, decimals = YLabelDecimalPlaces) # Will be co-erced to a string for us later.
 
     
     ax2.set_xticks( ticks = xTickPositions, labels = xLabels )

--- a/src/fcwt/boilerplate.py
+++ b/src/fcwt/boilerplate.py
@@ -49,13 +49,34 @@ def plot(input, fs, f0=0, f1=0, fn=0, nthreads=1, scaling="lin", fast=False, nor
 
     #plot spectrogram
     ax2.imshow(np.abs(output),aspect='auto')
+    
 
     #set time on x-axis every 10s and frequency on y-axis for 10 ticks
+    # So we have fixed 10 ticks on the Y-axis; 10s occupies one X tick
+
+    XTickInterval       = 10 # Seconds
+    YTickCount          = 10
+
     ax2.set_xlabel('Time (s)')
     ax2.set_ylabel('Frequency (Hz)')
     ax2.set_title('CWT')
-    ax2.set_xticks(np.arange(0,input.size,fs*10),np.arange(0,input.size/fs,10))
-    ax2.set_yticks(np.arange(0,fn,fn/10),np.round(freqs[::int(fn/10)]))
+
+
+    frequencySpacing = int(fn / YTickCount)    # Find the step size for the number of Y ticks
+
+    yFrequencies = freqs[::frequencySpacing]   # Select by stepping along this length; clamp at the number we are looking for in case we get one extra.
+
+    xTickPositions = np.arange(0, input.size, fs * XTickInterval) 
+    yTickPositions = np.arange(0, fn,         fn / YTickCount   )
+    
+    xLabels  = np.arange(0, input.size/fs, XTickInterval)
+
+    # Round the Y labels to be whole numbers
+    yLabels  = np. round(yFrequencies) # Will be co-erced to a string for us later.
+
+    
+    ax2.set_xticks( ticks = xTickPositions, labels = xLabels )
+    ax2.set_yticks( ticks = yTickPositions, labels = yLabels )
 
 
     plt.show()

--- a/src/fcwt/boilerplate.py
+++ b/src/fcwt/boilerplate.py
@@ -33,12 +33,7 @@ def cwt(input, fs, f0, f1, fn, nthreads=1, scaling="lin", fast=False, norm=True)
 
     return freqs, output
 
-def plot(input, fs, f0=0, f1=0, fn=0, nthreads=1, scaling="lin", fast=False, norm=True):
-    
-    f0 = f0 if f0 else 1/(input.size/fs)
-    f1 = f1 if f1 else fs/2
-    fn = fn if fn else 100
-    freqs, output = cwt(input, fs, f0, f1, fn, nthreads=nthreads, scaling=scaling, fast=fast, norm=norm)
+def _plot(input, freqs, output, fs, f0, f1, fn):
 
     #create two subplots
     fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
@@ -81,4 +76,16 @@ def plot(input, fs, f0=0, f1=0, fn=0, nthreads=1, scaling="lin", fast=False, nor
 
 
     plt.show()
+
+
+def plot(input, fs, f0=0, f1=0, fn=0, nthreads=1, scaling="lin", fast=False, norm=True):
+    
+    f0 = f0 if f0 else 1/(input.size/fs)
+    f1 = f1 if f1 else fs/2
+    fn = fn if fn else 100
+    freqs, output = cwt(input, fs, f0, f1, fn, nthreads=nthreads, scaling=scaling, fast=fast, norm=norm)
+
+    _plot(input, output, fs, f0, f1, fn)
+
+    
     

--- a/src/fcwt/boilerplate.py
+++ b/src/fcwt/boilerplate.py
@@ -62,9 +62,10 @@ def plot(input, fs, f0=0, f1=0, fn=0, nthreads=1, scaling="lin", fast=False, nor
     ax2.set_title('CWT')
 
 
-    frequencySpacing = int(fn / YTickCount)    # Find the step size for the number of Y ticks
+    frequencySpacing = int(fn / YTickCount)                # Find the step size for the number of Y ticks
 
-    yFrequencies = freqs[::frequencySpacing]   # Select by stepping along this length; clamp at the number we are looking for in case we get one extra.
+    yFrequencies = freqs[::frequencySpacing][0:YTickCount] # Select by stepping along this length; clamp at the number we are looking for in case we get one extra.
+
 
     xTickPositions = np.arange(0, input.size, fs * XTickInterval) 
     yTickPositions = np.arange(0, fn,         fn / YTickCount   )


### PR DESCRIPTION
When plotting my dataset, MPL complained about the number of ticks and labels as being unequal. The way the frequencies were sliced resulted in an off-by-one error. I reworked this to eliminate the bug in earlier commits; but have also since changed it to be inclusive of f0 and f1, seeing as these are important to label in the plot.